### PR TITLE
HAADVMaddRegistry.ps1

### DIFF
--- a/XAXD/AAD/HAADVMaddRegistry.ps1
+++ b/XAXD/AAD/HAADVMaddRegistry.ps1
@@ -1,0 +1,28 @@
+$VirtualDesktopKeyPath = 'HKLM:\Software\AzureAD\VirtualDesktop'
+$WorkplaceJoinKeyPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WorkplaceJoin'
+$MaxCount = 60
+
+for ($count = 1; $count -le $MaxCount; $count++)
+{
+    if ((Test-Path -Path $VirtualDesktopKeyPath) -eq $true)
+    {
+        $provider = (Get-Item -Path $VirtualDesktopKeyPath).GetValue("Provider", $null)
+        if ($provider -eq 'Citrix')
+        {
+            break;
+        }
+
+        if ($provider -eq 1)
+        {
+            Set-ItemProperty -Path $VirtualDesktopKeyPath -Name "Provider" -Value "Citrix" -Force
+            Set-ItemProperty -Path $WorkplaceJoinKeyPath -Name "autoWorkplaceJoin" -Value 1 -Force
+            Start-Sleep 5
+            dsregcmd /join
+            break
+        }
+    }
+
+    Start-Sleep 1
+}
+
+


### PR DESCRIPTION
For Citrix MCS provisioned Azure AD or Hybrid Azure AD joined machine catalogs that uses Windows 11 22H2 as master VMs’ OS, the VDA machines might stuck at “Initializing” status after startup. 
 
For Hybrid Azure AD joined machine catalogs, create a scheduled task in the master VM that executes the following commands at system startup using SYSTEM account. reg ADD HKLM\Software\AzureAD\VirtualDesktop /v Provider /t REG_SZ /d Citrix /f
 reg ADD HKLM\SOFTWARE\Policies\Microsoft\Windows\WorkplaceJoin /v autoWorkplaceJoin /t REG_DWORD /d 1 /f
 dsregcmd /join